### PR TITLE
Enhance CSS styling for the `simple` template

### DIFF
--- a/templates/epub3/template.css
+++ b/templates/epub3/template.css
@@ -1,14 +1,87 @@
 body {
-    text-align: justify;
-    line-height: 1.25em;
+    line-height: 1.5;
+    text-align: left;
+    font-kerning: normal;
+    font-variant: common-ligatures oldstyle-nums proportional-nums;
+    font-feature-settings: "kern", "liga", "clig", "onum", "pnum";
+}
+
+body * {
+    line-height: inherit;
+}
+
+h1, h2, h3 {
+    font-family: sans-serif;
+    text-align: center;
+    font-variant: common-ligatures lining-nums proportional-nums;
+    font-feature-settings: "kern", "liga", "clig", "lnum", "pnum";
+}
+
+code {
+    font-family: monospace;
+    font-variant: no-common-ligatures lining-nums;
+    font-feature-settings: "kern" 0, "liga" 0, "clig" 0, "lnum";
+}
+
+pre {
+    margin: 1em 0.5em;
+    border: 1px solid #aaa;
+    box-shadow: 5px 5px 8px #ccc;
+    padding: 0.5em;
+}
+
+h1, h2, h3, code {
+    line-height: 1.2;
+    -webkit-hyphens: none;
+    -moz-hyphens: none;
+    -ms-hyphens: none;
+    -epub-hyphens: none;
+    adobe-hyphenate: none;
+    hyphens: none;
+}
+
+p, blockquote {
+    font-family: serif;
+    -webkit-hyphenate-limit-before: 3;
+    -webkit-hyphenate-limit-after: 2;
+    -webkit-hyphenate-limit-lines: 2;
+    -ms-hyphenate-limit-chars: 6 3 2;
+    hyphenate-limit-chars: 6 3 2;
+    hyphenate-limit-lines: 2;
+}
+
+blockquote {
+    font-style: italic;
+    margin-left: 3em;
+    text-indent: -1.2ch;
+}
+
+blockquote:before {
+    content: "\201C\00A0";
+}
+
+blockquote:after {
+    content: "\00A0\201D";
 }
 
 p {
     margin: 0;
     padding: 0;
-    text-indent: 1.5em;
+    text-indent: 1.25em;
+    text-align: justify;
     widows: 2;
     orphans: 2;
+}
+
+a, a:link, a:visited {
+    color: inherit;
+    -webkit-text-fill-color: inherit;
+    text-decoration: underline dotted #888;
+}
+
+a:active, a:hover {
+    color: blue;
+    text-decoration: underline solid blue;
 }
 
 .epub-author {
@@ -36,7 +109,17 @@ p {
 }
 
 hr {
+    width: 100%;
+    height: 1em;
     border: 0;
-    border-bottom: 1px solid #dedede;
-    margin: 60px 10%;
+    margin: 1.5em auto;
+    text-align: center;
+    color: black;
+    overflow: hidden;
+    page-break-inside: avoid;
+    break-inside: avoid;
+}
+
+hr:before {
+    content: '* * *';
 }


### PR DESCRIPTION
- enable font ligatures
- explicitly set titles in sans-serif, text in serif, code in monospace
- show a box around code blocks
- print quotes in italic surrounded by double-quotes
- justify paragraphs, left-align code, center quotes and titles
- make links stand out less
- print "* * *" instead of a line between scenes
- increase line height a little, reduce text indent a little

See [demo](https://imgur.com/fpLJbTJ) for results.